### PR TITLE
Gemini (beta) chat 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@
 OPENAI_API_KEY=
 # Optional: change the web server port
 # PORT=3000
+
+# Google Generative AI (Gemini) API key
+GOOGLE_API_KEY=
+# Optional alias
+GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # OpenAI Invoice Runner
 
-A simple Node + Express web app to test invoice extraction prompts, chat with OpenAI models, and run vendor matching. It has three tabs:
+A simple Node + Express web app to test invoice extraction prompts, chat with OpenAI models, try Gemini models, and run vendor matching. It has four tabs:
 
 - Home: Runs a one-shot prompt against your local invoice text and images, and shows token usage.
-- Chat Completion: A chat UI with optional multi-file image upload, include-history toggle, and "New chat" button.
+- Chat Completion: A chat UI for OpenAI models with optional multi-file image upload, include-history toggle, “New chat”, and a red expand editor button on the input box.
+- Gemini (beta): A chat UI for Google Gemini models with similar controls (adds top_k) and the same red expand editor button.
 - Vendor Matching: Finds best vendor matches from CSVs in the `vendors/` folder based on a Phase 1 JSON payload.
 
 ## Features
 - Reads OCR text from `text/` and aggregates it into the prompt.
 - Loads all images from `images/` and sends them to the model.
 - Optional LM Studio OCR: when enabled in the Home tab, sends images to a local LM Studio server (model `nanonets-ocr-s`) to extract raw text, with automatic fallback to the `text/` files if LM Studio is unavailable.
+- Gemini chat support via Google Generative AI (`/api/gemini-chat`).
+- Chat input “expand editor” for composing long prompts (both OpenAI Chat and Gemini tabs).
 - Routes reasoning models (gpt-5, o3, o1) to the Responses API with configurable reasoning effort.
 - Routes other models (gpt-4o, gpt-4o-mini, gpt-5-mini) to Chat Completions API.
 - Token usage displayed on the Home tab; chat endpoint also returns usage.
@@ -21,6 +24,7 @@ A simple Node + Express web app to test invoice extraction prompts, chat with Op
 - Node.js 18+ (LTS recommended)
 - OpenAI API Key
 - (Optional) LM Studio running with an OCR-capable model (tested with `nanonets-ocr-s`) at `http://172.16.7.50:1234`.
+- (Optional for Gemini) Google Generative AI key in `.env` as `GOOGLE_API_KEY` (or `GEMINI_API_KEY`).
 
 ## Quick start
 1. Clone the repo
@@ -47,6 +51,7 @@ A simple Node + Express web app to test invoice extraction prompts, chat with Op
 ## Configuration
 - API key: `.env`
   - `OPENAI_API_KEY=your_key_here`
+  - `GOOGLE_API_KEY=your_key_here` (or `GEMINI_API_KEY`) — required for Gemini tab
   - Optional: `PORT=3000`
 - Hardcoded paths (Windows):
   - Text directory: `C:\\codebase\\OpenaiApi\\text` (see `utils/PromptText.js`)
@@ -68,6 +73,7 @@ A simple Node + Express web app to test invoice extraction prompts, chat with Op
 
 ## Project structure
 - `server.js` — Express server, static web, `/api/run`, `/api/chat`, and `/api/vendor-matching`
+  - Also exposes `/api/gemini-chat` for the Gemini tab
 - `index.js` — Runner for Home tab; prepares prompt + images and calls OpenAI
 - `const.js` — Prompt template and JSON schema description
 - `utils/PromptText.js` — Aggregates `.txt` files in `text/` into a single string
@@ -88,6 +94,13 @@ A simple Node + Express web app to test invoice extraction prompts, chat with Op
   - Type a message and optionally attach one or more images
   - Include history toggle controls whether to send prior exchanges
   - New chat clears the conversation in the browser
+  - Use the red 🔎 button in the input to open a large editor for long prompts
+
+- Gemini (beta) tab
+  - Similar to Chat Completion but calls Gemini models; supports images
+  - Models include `gemini-1.5-flash`, `gemini-1.5-pro`, `gemini-2.0-flash-exp`; includes `top_k`
+  - Requires `GOOGLE_API_KEY` in `.env`
+  - The red 🔎 button expands the message editor
 
 - Vendor Matching tab
   - Paste your Phase 1 JSON (shape: `{ remitToAddress, otherSupplierAddresses?, vendorCompanyName? }`)
@@ -108,6 +121,7 @@ A simple Node + Express web app to test invoice extraction prompts, chat with Op
  - Vendor Matching: "No CSV files found" — ensure CSVs exist under `vendors/`
  - Vendor Matching: Empty results — verify Phase 1 addresses and that CSVs contain expected columns
  - LM Studio OCR: If you enabled the toggle but still see text from the `text/` folder, LM Studio likely failed and the app used the fallback. Ensure LM Studio is running and reachable at `http://172.16.7.50:1234`. To change the URL/model, edit `utils/PromptText.js`.
+ - Gemini: 400 "Missing GOOGLE_API_KEY" — set `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `.env` and restart
 
 ## Security
 - Do not commit `.env` or any API keys

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "node-fetch": "^3.3.2",
     "multer": "^2.0.2",
     "nodemon": "^3.1.10",
-    "openai": "^5.15.0"
+  "openai": "^5.15.0",
+  "@google/generative-ai": "^0.21.0"
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,7 @@
           <button class="tab-btn active" data-tab="home">Home</button>
           <button class="tab-btn" data-tab="chat">Chat Completion</button>
           <button class="tab-btn" data-tab="vendor">Vendor Matching</button>
+          <button class="tab-btn" data-tab="gemini">Gemini (beta)</button>
         </nav>
       </header>
       <div class="layout tab-content active" id="tab-home">
@@ -199,12 +200,82 @@
               <button type="button" id="new-chat">New chat</button>
               <label class="file"><input type="file" id="chat-file" multiple /></label>
             </div>
-            <textarea id="chat-input" name="prompt" rows="8" placeholder="Type a message or paste a longer prompt..."></textarea>
+            <div class="compose-wrap">
+              <textarea id="chat-input" name="prompt" rows="8" placeholder="Type a message or paste a longer prompt..."></textarea>
+              <button type="button" id="chat-compose" class="icon-btn" title="Expand editor">🔎</button>
+            </div>
+            <button type="submit">Send</button>
+          </form>
+        </section>
+      </div>
+      <!-- Gemini (beta) Tab -->
+      <div class="layout tab-content" id="tab-gemini">
+        <aside class="sidebar">
+          <form id="gem-params-form">
+            <div class="row">
+              <label>Model</label>
+              <select name="model">
+                <option value="gemini-1.5-flash" selected>gemini-1.5-flash</option>
+                <option value="gemini-1.5-pro">gemini-1.5-pro</option>
+                <option value="gemini-2.0-flash-exp">gemini-2.0-flash-exp</option>
+              </select>
+            </div>
+            <div class="row">
+              <label>max_output_tokens</label>
+              <input name="max_tokens" type="number" value="2048" />
+            </div>
+            <div class="row">
+              <label>temperature</label>
+              <input name="temperature" type="number" step="0.1" value="0.7" />
+            </div>
+            <div class="row">
+              <label>top_p</label>
+              <input name="top_p" type="number" step="0.1" value="1" />
+            </div>
+            <div class="row">
+              <label>top_k</label>
+              <input name="top_k" type="number" step="1" value="40" />
+            </div>
+            <div class="row">
+              <label>timeout (ms)</label>
+              <input name="timeout" type="number" value="60000" />
+            </div>
+          </form>
+        </aside>
+        <section class="output">
+          <h2>Gemini Chat</h2>
+          <div class="chat-box" id="gem-chat-box"></div>
+          <form id="gem-chat-form" class="chat-input">
+            <div class="chat-tools">
+              <label class="toggle"><input type="checkbox" id="gem-include-history" checked /> Include history</label>
+              <button type="button" id="gem-new-chat">New chat</button>
+              <label class="file"><input type="file" id="gem-chat-file" multiple /></label>
+            </div>
+            <div class="compose-wrap">
+              <textarea id="gem-chat-input" name="prompt" rows="8" placeholder="Type a message or paste a longer prompt..."></textarea>
+              <button type="button" id="gem-compose" class="icon-btn" title="Expand editor">🔎</button>
+            </div>
             <button type="submit">Send</button>
           </form>
         </section>
       </div>
     </main>
+    <!-- Reusable Compose Editor Modal -->
+    <div id="compose-modal" class="modal" hidden>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3>Edit Message</h3>
+          <button type="button" id="compose-close" class="icon-btn" title="Close">✕</button>
+        </div>
+        <div class="modal-body">
+          <textarea id="compose-editor" rows="24" spellcheck="false"></textarea>
+        </div>
+        <div class="modal-footer">
+          <button type="button" id="compose-cancel">Cancel</button>
+          <button type="button" id="compose-save" class="primary">Save</button>
+        </div>
+      </div>
+    </div>
     <script defer src="/main.js"></script>
   </body>
   </html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -41,6 +41,19 @@ pre { white-space: pre-wrap; word-break: break-word; background: #0f1524; paddin
 .chat-msg .role { color: var(--muted); font-size: 0.85rem; }
 .chat-msg .bubble { background: #121826; padding: 8px 10px; border-radius: 6px; display: inline-block; margin-top: 4px; }
 .chat-input { display: grid; grid-template-columns: 1fr auto; gap: 8px; }
+.compose-wrap { position: relative; }
+.compose-wrap textarea { width: 100%; }
+.compose-wrap .icon-btn { position: absolute; right: 8px; bottom: 8px; }
+/* Make compose-arrow buttons red */
+.compose-wrap .icon-btn {
+  background: #dc3545; /* red */
+  border-color: #b02a37;
+  color: #fff;
+}
+.compose-wrap .icon-btn:hover {
+  background: #c82333;
+  border-color: #9a2530;
+}
 .chat-input textarea#chat-input { resize: vertical; min-height: 160px; }
 .chat-tools { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
 .toggle input { margin-right: 6px; }
@@ -59,6 +72,20 @@ textarea { width: 100%; min-height: 140px; background: #0f1524; color: var(--tex
 /* Copy button */
 .copy-btn { margin-left: 8px; background: #253048; border: 1px solid #32405f; padding: 4px 8px; font-size: 12px; border-radius: 5px; color: #d9e3f0; }
 .copy-btn:hover { background: #2b3856; }
+
+/* Small icon button */
+.icon-btn { margin-left: 8px; padding: 4px 8px; border: 1px solid #ccc; background: #f7f7f7; border-radius: 4px; cursor: pointer; }
+
+/* Modal */
+.modal { position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+.modal[hidden] { display: none; }
+.modal-content { width: min(1000px, 96vw); height: min(80vh, 900px); background: #fff; border-radius: 8px; display: flex; flex-direction: column; box-shadow: 0 8px 24px rgba(0,0,0,0.2); color: #222; }
+.modal-header, .modal-footer { padding: 10px 12px; border-bottom: 1px solid #eee; display: flex; align-items: center; }
+.modal-header { justify-content: space-between; }
+.modal-footer { border-bottom: none; border-top: 1px solid #eee; justify-content: flex-end; gap: 8px; }
+.modal-body { flex: 1; padding: 8px 12px; }
+#compose-editor { width: 100%; height: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 13px; }
+.primary { background: #0d6efd; color: #fff; border-color: #0d6efd; }
 
 /* Attachment chips */
 .attachments { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 6px; }


### PR DESCRIPTION
Summary
- Adds Gemini (beta) tab end-to-end: UI, backend /api/gemini-chat via @google/generative-ai
- Adds red 🔎 compose editor for long prompts in Chat and Gemini tabs
- Home tab: optional LM Studio OCR toggle with fallback to text files
- Documentation and .env.example updated accordingly

Changes
- .env.example: Added GOOGLE_API_KEY and GEMINI_API_KEY placeholders
- README.md: Documented Gemini tab, compose editor, LM Studio OCR toggle, troubleshooting
- package.json: Added @google/generative-ai dependency
- server.js: Implemented /api/gemini-chat, refined /api/chat, run endpoint propagation
- web/index.html: New Gemini tab UI, shared compose modal, Chat/Gemini compose buttons
- web/main.js: Chat and Gemini flows, compose modal wiring, copy buttons, numeric coercion
- web/styles.css: Styles for compose modal, red icon button, collapsibles, chips

Testing
- Start server, verify:
  - Home: LM Studio OCR checkbox toggles; run shows Result/Prompt/Usage sections
  - Chat: Send text + optional images; include-history toggle; expand editor works
  - Gemini: Send text + images; requires GOOGLE_API_KEY in .env
  - Vendor Matching: Paste Phase 1 JSON; results load from vendors folder

Notes
- LM Studio OCR URL/model currently hardcoded in utils/PromptText.js (nanonets-ocr-s @ http://172.16.7.50:1234); falls back to text/ if unavailable
- No lockfile edits included; run npm install to sync deps if needed